### PR TITLE
update deprecated code

### DIFF
--- a/src/game.py
+++ b/src/game.py
@@ -8,7 +8,7 @@ class Game(cmd.Cmd):
     def __init__(self):
         cmd.Cmd.__init__(self)
         
-        self.dbfile = tempfile.mktemp()
+        self.dbfile = tempfile.mkstemp()[1]
         shutil.copyfile("game.db", self.dbfile)
         
         self.loc = get_room(1, self.dbfile)


### PR DESCRIPTION
use tempfile.mkstemp() instead of tempfile.mktemp()

by using mkstemp() instead of mktemp(), the code is up to speed with the latest versions.
as mkstemp() returns a tuple with the absolute path as the second element, adding [1] at the end of tempfile.mkstemp(), the code is not broken (tested)